### PR TITLE
adds typing_extensions to cantera run requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -222,6 +222,7 @@ outputs:
     test:
       requires:
         - pytest
+        - pip
         - pint
         - {{ pin_subpackage('libcantera-devel', exact=True) }}
         - cmake

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -239,6 +239,7 @@ outputs:
       files:
         - test-lib
       commands:
+        - pip check
         - cat ${CONDA_PREFIX}/conda-meta/cantera-*.json  # [not win]
         - type %CONDA_PREFIX%\conda-meta\cantera-*.json  # [win]
         - uname -a  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -223,6 +223,7 @@ outputs:
       requires:
         - pytest
         - pip
+        - pip
         - pint
         - {{ pin_subpackage('libcantera-devel', exact=True) }}
         - cmake
@@ -239,6 +240,7 @@ outputs:
       files:
         - test-lib
       commands:
+        - pip check
         - pip check
         - cat ${CONDA_PREFIX}/conda-meta/cantera-*.json  # [not win]
         - type %CONDA_PREFIX%\conda-meta\cantera-*.json  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -151,7 +151,8 @@ outputs:
         - pkgconfig
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
-        - numpy
+        - numpy <2.4  # [py==314]
+        - numpy       # [py!=314]
         - python
       files:
         - test-lib
@@ -171,7 +172,8 @@ outputs:
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
         # These are needed to support cross-compiling. See
         # https://conda-forge.org/docs/maintainer/knowledge_base/#details-about-cross-compiled-python-packages
-        - numpy                                  # [build_platform != target_platform]
+        - numpy <2.4                             # [build_platform != target_platform and py==314]
+        - numpy                                  # [build_platform != target_platform and py!=314]
         - cython                                 # [build_platform != target_platform]
         - {{ compiler('c') }}
         - {{ stdlib("c") }}
@@ -185,7 +187,8 @@ outputs:
         - setuptools
         - packaging
         - libboost-headers
-        - numpy
+        - numpy <2.4  # [py==314]
+        - numpy       # [py!=314]
         - fmt
         - eigen
         - yaml-cpp
@@ -207,6 +210,9 @@ outputs:
         - libgomp      # [linux]
       run:
         - python
+        # numpy is otherwise pulled in only via its run-export, which allows any
+        # 2.x; cap it on 3.14 where numpy 2.4 breaks the test suite (temporary).
+        - numpy <2.4  # [py==314]
         - typing_extensions >=4.13.0
         - ruamel.yaml
         - {{ pin_subpackage('libcantera', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     folder: data/example_data
 
 build:
-  number: 0
+  number: 1
   include_recipe: True
   script_env:
     - "CT_GIT_COMMIT=4a8358eb80cfeb50474386b5f9ec0b3a83519889"
@@ -206,6 +206,7 @@ outputs:
         - libgomp      # [linux]
       run:
         - python
+        - typing_extensions >=4.13.0
         - ruamel.yaml
         - {{ pin_subpackage('libcantera', exact=True) }}
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,8 @@ requirements:
     - ruamel.yaml
   host:
     - python >=3.10
-    - numpy
+    - numpy <2.4  # [py==314]
+    - numpy       # [py!=314]
     - libboost-devel
     - fmt
     - eigen

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -223,7 +223,6 @@ outputs:
       requires:
         - pytest
         - pip
-        - pip
         - pint
         - {{ pin_subpackage('libcantera-devel', exact=True) }}
         - cmake
@@ -240,7 +239,6 @@ outputs:
       files:
         - test-lib
       commands:
-        - pip check
         - pip check
         - cat ${CONDA_PREFIX}/conda-meta/cantera-*.json  # [not win]
         - type %CONDA_PREFIX%\conda-meta\cantera-*.json  # [win]


### PR DESCRIPTION
## Summary

cantera 3.2.0's package metadata declares `typing_extensions>=4.13.0` as an **unconditional** runtime dependency:

```console
$ python -c "from importlib.metadata import requires; \
    print([r for r in requires('cantera') if 'typing' in r])"
['typing_extensions>=4.13.0']
```

However, the `cantera` output's `run:` requirements do not include `typing_extensions` (it is only listed under `host:` with a `# [py < 311]` selector). As a result, on Python ≥ 3.11 (e.g. 3.14) installing `cantera` does not pull in `typing_extensions`, and `pip check` reports:

```
cantera 3.2.0 requires typing-extensions, which is not installed
```

This breaks `pip check` for cantera itself and for any downstream conda package that depends on cantera and runs `pip check` in its tests. (for example, pyMARS: https://github.com/conda-forge/staged-recipes/pull/33909)

## Change

Add `typing_extensions >=4.13.0` to the `cantera` output's `run:` requirements, matching the dependency cantera declares in its wheel metadata, and bump the build number.

## Note

The `# [py < 311]` selector elsewhere reflects that cantera only *imports* `typing_extensions` on older Python, but cantera's published metadata declares it unconditionally. Making the runtime dependency unconditional here is the appropriate fix on the feedstock side. (Alternatively this could be addressed upstream by adding a `; python_version < "3.11"` marker to the dependency, but that would require a new release.)

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

